### PR TITLE
dal_admin_filters: make it easy to override the qs for form field

### DIFF
--- a/dal_admin_filters/__init__.py
+++ b/dal_admin_filters/__init__.py
@@ -42,7 +42,7 @@ class AutocompleteFilter(SimpleListFilter):
         self._add_media(model_admin)
 
         field = forms.ModelChoiceField(
-            queryset=getattr(model, self.field_name).get_queryset(),
+            queryset=self.get_queryset_for_field(model, self.field_name),
             widget=autocomplete.ModelSelect2(
                 url=self.autocomplete_url,
             )
@@ -57,6 +57,9 @@ class AutocompleteFilter(SimpleListFilter):
             value=self.used_parameters.get(self.parameter_name, ''),
             attrs=attrs
         )
+
+    def get_queryset_for_field(self, model, name):
+        return getattr(model, self.field_name).get_queryset()
 
     def _add_media(self, model_admin):
 


### PR DESCRIPTION
Helpful if you don't want to filter through different models because
you need to initialize the field to something sensible if you want
to have the filter label to be shown.