### PR TITLE
Use parameter_name attribute if provided

### DIFF
--- a/dal_admin_filters/__init__.py
+++ b/dal_admin_filters/__init__.py
@@ -34,12 +34,9 @@ class AutocompleteFilter(SimpleListFilter):
         )
 
     def __init__(self, request, params, model, model_admin):
-        if self.parameter_name:
-            raise AttributeError(
-                'Rename attribute `parameter_name` to '
-                '`field_name` for {}'.format(self.__class__)
-            )
-        self.parameter_name = '{}__{}__exact'.format(self.field_name, self.field_pk)
+        if not self.parameter_name:
+            self.parameter_name = '{}__{}'.format(
+                self.field_name, self.field_pk)
         super(AutocompleteFilter, self).__init__(request, params, model, model_admin)
 
         self._add_media(model_admin)


### PR DESCRIPTION
- Remove unnecessary `exact` lookup
- Use `parameter_name` class attribute if given, else construct it from `field_name` and `field_pk`. This attribute is needed to check valid lookups in `model_admin` [method](https://github.com/django/django/blob/76b3fc5c8d8dffb441aaa08f75833888be2107af/django/contrib/admin/options.py#L410) `lookup_allowed`. 